### PR TITLE
Load cudamat libraries by absolute path on Linux/Mac

### DIFF
--- a/cudamat.py
+++ b/cudamat.py
@@ -7,7 +7,7 @@ MAX_ONES = 1024*256
 if platform.system() == 'Windows':
     _cudamat = ct.cdll.LoadLibrary('libcudamat.dll')
 else:
-    _cudamat = ct.cdll.LoadLibrary('libcudamat.so')
+    _cudamat = ct.cdll.LoadLibrary(os.path.join(os.path.dirname(__file__), 'libcudamat.so'))
 
 _cudamat.get_last_cuda_error.restype = ct.c_char_p
 _cudamat.cublas_init.restype = ct.c_int

--- a/learn.py
+++ b/learn.py
@@ -1,3 +1,4 @@
+import os
 import pdb
 import platform
 import warnings
@@ -8,7 +9,7 @@ from cudamat import generate_exception
 if platform.system() == 'Windows':
     _cudalearn = ct.cdll.LoadLibrary('libcudalearn.dll')
 else:
-    _cudalearn = ct.cdll.LoadLibrary('libcudalearn.so')
+    _cudalearn = ct.cdll.LoadLibrary(os.path.join(os.path.dirname(__file__), 'libcudalearn.so'))
 
 _cudalearn.mult_by_sigmoid_deriv.restype = ct.c_int
 


### PR DESCRIPTION
To make cudamat easier to install, load the .so files by absolute path (we know their locations anyway). This way the cudamat directory does not need to be on the user's LD_LIBRARY_PATH for cudamat to work.

I don't know if the same change would be possible/helpful on Windows. I'll happily extend the pull request if somebody can test this.
