### PR TITLE
Allow CUDAMatrix.slice() to produce a view into the CPU copy as well

### DIFF
--- a/cudamat.py
+++ b/cudamat.py
@@ -263,7 +263,7 @@ class CUDAMatrix(object):
         err_code = _cudamat.copy_to_host(self.p_mat)
         if err_code:
             raise generate_exception(err_code)
-    
+
     def assign(self, val):
         """Assign val to self, where val can be a scalar or a CUDAMatrix
         with the same dimensions as self. """


### PR DESCRIPTION
This adds a flag `include_host` to `CUDAMatrix.slice()` to have it create a view into the CPU copy of the matrix along with the view into the GPU copy.
