### PR TITLE
Add CUDAMatrix.apply_soft_threshold

### DIFF
--- a/cudamat.cu
+++ b/cudamat.cu
@@ -743,6 +743,25 @@ extern int apply_tanh(cudamat* mat, cudamat* target) {
     return 0;
 }
 
+extern int apply_soft_threshold(cudamat* mat, float alpha, cudamat* target) {
+    unsigned int len = mat->size[0] * mat->size[1];
+
+    if (!mat->on_device || !target->on_device)
+        return ERROR_NOT_ON_DEVICE;
+
+    if (mat->size[0] != target->size[0] || mat->size[1] != target->size[1])
+        return ERROR_INCOMPATIBLE_DIMENSIONS;
+
+    kApplySoftThreshold<<<NUM_VECTOR_OP_BLOCKS,NUM_VECTOR_OP_THREADS_PER_BLOCK>>>(mat->data_device, alpha, target->data_device, len);
+
+    cudaThreadSynchronize();
+
+    if (checkCUDAError())
+        return CUDA_ERROR;
+
+    return 0;
+}
+
 extern int apply_abs(cudamat* mat, cudamat* target) {
     unsigned int len = mat->size[0] * mat->size[1];
 

--- a/cudamat.py
+++ b/cudamat.py
@@ -47,6 +47,7 @@ _cudamat.max_by_axis.restype = ct.c_int
 _cudamat.sign.restype = ct.c_int
 _cudamat.apply_sigmoid.restype = ct.c_int
 _cudamat.apply_tanh.restype = ct.c_int
+_cudamat.apply_soft_threshold.restype = ct.c_int
 _cudamat.apply_abs.restype = ct.c_int
 _cudamat.apply_log_1_plus_exp.restype = ct.c_int
 _cudamat.apply_log.restype = ct.c_int
@@ -603,6 +604,22 @@ class CUDAMatrix(object):
 
         return sigmoid(self, target)
 
+    def apply_tanh(self, target = None):
+        """
+        Apply the tanh to each element of the matrix.
+        """
+
+        return tanh(self, target)
+
+    def apply_soft_threshold(self, alpha, target = None):
+        """
+        Apply the soft threshold function to each element of the matrix:
+
+        x = sign(x) * max(0, abs(x) - alpha)
+        """
+
+        return soft_threshold(self, alpha, target)
+
     def reciprocal(self, target = None):
         """
         Find the reciprocal of each element of the matrix.
@@ -946,6 +963,22 @@ def tanh(mat, target = None):
         target = mat
 
     err_code = _cudamat.apply_tanh(mat.p_mat, target.p_mat)
+    if err_code:
+        raise generate_exception(err_code)
+
+    return target
+
+def soft_threshold(mat, alpha, target = None):
+    """
+    Apply the soft threshold function to each element of the matrix:
+
+    mat = sign(mat) * max(0, abs(mat) - alpha)
+    """
+
+    if not target:
+        target = mat
+
+    err_code = _cudamat.apply_soft_threshold(mat.p_mat, ct.c_float(alpha), target.p_mat)
     if err_code:
         raise generate_exception(err_code)
 

--- a/cudamat_kernels.cu
+++ b/cudamat_kernels.cu
@@ -226,6 +226,16 @@ __global__ void kApplyTanh(float* mat, float* target, unsigned int len) {
     }
 }
 
+__global__ void kApplySoftThreshold(float* mat, float alpha, float* target, unsigned int len) {
+    const unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    const unsigned int numThreads = blockDim.x * gridDim.x;
+
+    for (unsigned int i = idx; i < len; i += numThreads) {
+        float f = mat[i];
+        target[i] = f > 0 ? max(0., f - alpha) : min(0., f + alpha);
+    }
+}
+
 __global__ void kApplyAbs(float* mat, float* target, unsigned int len) {
     const unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
     const unsigned int numThreads = blockDim.x * gridDim.x;

--- a/cudamat_kernels.cuh
+++ b/cudamat_kernels.cuh
@@ -42,6 +42,7 @@ __global__ void kMaxColumnwise(float* mat, float* target, unsigned int width, un
 __global__ void kSign(float* mat, float* target, unsigned int len);
 __global__ void kApplySigmoid(float* mat, float* target, unsigned int len);
 __global__ void kApplyTanh(float* mat, float* target, unsigned int len);
+__global__ void kApplySoftThreshold(float* mat, float alpha, float* target, unsigned int len);
 __global__ void kApplyAbs(float* mat, float* target, unsigned int len);
 __global__ void kApplyLog1PlusExp(float* mat, float* target, unsigned int len);
 __global__ void kLog(float* mat, float* target, unsigned int len);

--- a/test_cudamat.py
+++ b/test_cudamat.py
@@ -492,6 +492,45 @@ def test_sigmoid():
     assert np.max(np.abs(c - m1.numpy_array)) < 10**-4, "Error in CUDAMatrix.apply_sigmoid exceeded threshold"
     assert np.max(np.abs(c - m2.numpy_array)) < 10**-4, "Error in CUDAMatrix.apply_sigmoid exceeded threshold"
 
+def test_tanh():
+    m = 256
+    n = 128
+    a = np.array(np.random.randn(m, n)*10, dtype=np.float32, order='F')
+    b = np.array(np.random.randn(m, n)*10, dtype=np.float32, order='F')
+
+    c = np.tanh(a)
+
+    m1 = cm.CUDAMatrix(a)
+    m2 = cm.CUDAMatrix(b)
+    m1.apply_tanh(target = m2)
+    m1.apply_tanh()
+
+    m1.copy_to_host()
+    m2.copy_to_host()
+
+    assert np.max(np.abs(c - m1.numpy_array)) < 10**-4, "Error in CUDAMatrix.apply_tanh exceeded threshold"
+    assert np.max(np.abs(c - m2.numpy_array)) < 10**-4, "Error in CUDAMatrix.apply_tanh exceeded threshold"
+
+def test_soft_threshold():
+    m = 256
+    n = 128
+    a = np.array(np.random.randn(m, n)*10, dtype=np.float32, order='F')
+    b = np.array(np.random.randn(m, n)*10, dtype=np.float32, order='F')
+
+    alpha = 0.5
+    c = np.sign(a) * np.maximum(0, np.abs(a) - alpha)
+
+    m1 = cm.CUDAMatrix(a)
+    m2 = cm.CUDAMatrix(b)
+    m1.apply_soft_threshold(alpha, target = m2)
+    m1.apply_soft_threshold(alpha)
+
+    m1.copy_to_host()
+    m2.copy_to_host()
+
+    assert np.max(np.abs(c - m1.numpy_array)) < 10**-4, "Error in CUDAMatrix.apply_soft_threshold exceeded threshold"
+    assert np.max(np.abs(c - m2.numpy_array)) < 10**-4, "Error in CUDAMatrix.apply_soft_threshold exceeded threshold"
+
 def test_log():
     m = 256
     n = 128


### PR DESCRIPTION
This adds `CUDAMatrix.apply_soft_threshold()` and `soft_threshold()`. Soft thresholding was used by Coates/Ng, "The Importance of Encoding Versus Training with Sparse Coding and Vector Quantization" (ICML 2011) as a cheap way to obtain sparsely activated features. In addition, it allows to implement projected gradient descent for an L1-regularized objective (see e.g. Murphy's book, Section 13.4.3.2); which is better than `W.subtract_mult(sign(W), eta*weight_cost)` if you're hoping to get actual zeros into your weights.

While we're at it, the pull request adds `CUDAMatrix.apply_tanh()` and accompanying test.
