### PR TITLE
Fix missing SYNC_THREADS check in equals()

### DIFF
--- a/cudamat.cu
+++ b/cudamat.cu
@@ -623,7 +623,8 @@ extern int equals(cudamat* mat1, cudamat* mat2, cudamat* target) {
 
     kEquals<<<NUM_VECTOR_OP_BLOCKS,NUM_VECTOR_OP_THREADS_PER_BLOCK>>>(mat1->data_device, mat2->data_device, target->data_device, len);
 
-    cudaThreadSynchronize();
+    if (SYNC_THREADS)
+        cudaThreadSynchronize();
 
     if (checkCUDAError())
         return CUDA_ERROR;
@@ -645,7 +646,8 @@ extern int equals_scalar(cudamat* mat, float val, cudamat* target) {
 
     kEqualsScalar<<<NUM_VECTOR_OP_BLOCKS,NUM_VECTOR_OP_THREADS_PER_BLOCK>>>(mat->data_device, val, target->data_device, len);
 
-    cudaThreadSynchronize();
+    if (SYNC_THREADS)
+        cudaThreadSynchronize();
 
     if (checkCUDAError())
         return CUDA_ERROR;


### PR DESCRIPTION
The implementation of `equals()` and `equals_scalar()` in `cudamat.cu` did not check for `SYNC_THREADS` before calling `cudaThreadSynchronize()`.
