### PR TITLE
Fix inferred path for .so files if importing in same directory

### DIFF
--- a/cudamat.py
+++ b/cudamat.py
@@ -7,7 +7,7 @@ MAX_ONES = 1024*256
 if platform.system() == 'Windows':
     _cudamat = ct.cdll.LoadLibrary('libcudamat.dll')
 else:
-    _cudamat = ct.cdll.LoadLibrary(os.path.join(os.path.dirname(__file__), 'libcudamat.so'))
+    _cudamat = ct.cdll.LoadLibrary(os.path.join(os.path.dirname(__file__) or os.path.curdir, 'libcudamat.so'))
 
 _cudamat.get_last_cuda_error.restype = ct.c_char_p
 _cudamat.cublas_init.restype = ct.c_int

--- a/learn.py
+++ b/learn.py
@@ -9,7 +9,7 @@ from cudamat import generate_exception
 if platform.system() == 'Windows':
     _cudalearn = ct.cdll.LoadLibrary('libcudalearn.dll')
 else:
-    _cudalearn = ct.cdll.LoadLibrary(os.path.join(os.path.dirname(__file__), 'libcudalearn.so'))
+    _cudalearn = ct.cdll.LoadLibrary(os.path.join(os.path.dirname(__file__) or os.path.curdir, 'libcudalearn.so'))
 
 _cudalearn.mult_by_sigmoid_deriv.restype = ct.c_int
 


### PR DESCRIPTION
This fixes the inferred path for the .so files when importing the module from an interactive Python shell in the same directory. (In this case, `__file__` does not have any path information and `os.path.dirname(__file__)` returns an empty string. We solve this by using the path `'.'` in this case.)
