### PR TITLE
Fix warning about double/float conversion in kReciprocal() kernel

### DIFF
--- a/cudamat_kernels.cu
+++ b/cudamat_kernels.cu
@@ -584,7 +584,7 @@ __global__ void kReciprocal(float* mat, float* target, unsigned int len) {
     const unsigned int numThreads = blockDim.x * gridDim.x;
 
     for (unsigned int i = idx; i < len; i += numThreads)
-        target[i] = 1. / mat[i];
+        target[i] = 1.f / mat[i];
 }
 
 __global__ void kAddColVector(float* mat, float* vec, float* tgtMat, unsigned int width,


### PR DESCRIPTION
When compiling cudamat, I always get a warning:

```
ptxas info    : 0 bytes gmem
ptxas info    : Compiling entry function '__cuda_dummy_entry__' for 'sm_10'
ptxas info    : Used 0 registers
ptxas /tmp/tmpxft_00003909_00000000-10_cudamat_kernels.ptx, line 5212; warning : Double is not supported. Demoting to float
```

By pressing CTRL+Z during make and opening the mentioned temporary file, I found that this is because of the double precision constant in `kReciprocal()`. Replacing it with a float solves the issue.

For GPUs with higher compute capability, we could also use a double there, for increased precision... this would need some changes to the Makefile, though.
