### PR TITLE
Change git clone url in README from SSH to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Download
 You can obtain the latest release from the repository by typing:
 
 ```bash
-git clone git@github.com:cudamat/cudamat.git
+git clone https://github.com/cudamat/cudamat.git
 ```
 
 You can also download one of the releases from the [releases](https://github.com/cudamat/cudamat/releases) section.


### PR DESCRIPTION
This changes the `git clone` command in the README to use HTTPS instead of SSH (otherwise you'd need a github account to clone).
