### PR TITLE
Added function to calculate the L1 regularization penalty.

### DIFF
--- a/learn.cu
+++ b/learn.cu
@@ -31,4 +31,24 @@ extern int mult_by_sigmoid_deriv(cudamat* target, cudamat* acts) {
     return 0;
 }
 
+extern int calculate_l1_penalty(cudamat* mat, float alpha, cudamat* target) {
+    unsigned int len = mat->size[0] * mat->size[1];
+
+    if (!mat->on_device || !target->on_device)
+        return ERROR_NOT_ON_DEVICE;
+
+    if (mat->size[0] != target->size[0] || mat->size[1] != target->size[1])
+        return ERROR_INCOMPATIBLE_DIMENSIONS;
+
+    kCalculateL1Penalty<<<NUM_VECTOR_OP_BLOCKS,NUM_VECTOR_OP_THREADS_PER_BLOCK>>>(mat->data_device, alpha, target->data_device, len);
+
+    if (SYNC_THREADS)
+        cudaThreadSynchronize();
+
+    if (checkCUDAError())
+        return CUDA_ERROR;
+
+    return 0;
+}
+
 }

--- a/learn.py
+++ b/learn.py
@@ -12,6 +12,7 @@ else:
     _cudalearn = ct.cdll.LoadLibrary(os.path.join(os.path.dirname(__file__) or os.path.curdir, 'libcudalearn.so'))
 
 _cudalearn.mult_by_sigmoid_deriv.restype = ct.c_int
+_cudalearn.calculate_l1_penalty.restype = ct.c_int
 
 def mult_by_sigmoid_deriv(target, acts):
     """
@@ -23,3 +24,24 @@ def mult_by_sigmoid_deriv(target, acts):
     err_code = _cudalearn.mult_by_sigmoid_deriv(target.p_mat, acts.p_mat)
     if err_code:
         raise generate_exception(err_code)
+
+def calculate_l1_penalty(mat, alpha, target = None):
+    """
+    Calculates the L1 regularization penalty of size p to mat.
+    
+    Equivalent to:
+        l1_penalty = alpha * np.sign(X)
+        result = np.where(alpha > np.abs(X), X, l1_penalty) # don't overshoot 0
+    """
+
+    if not target:
+        target = mat
+
+    elif isinstance(alpha, (int, float)):
+        err_code = _cudalearn.calculate_l1_penalty(mat.p_mat, ct.c_float(alpha), target.p_mat)
+        if err_code:
+            raise generate_exception(err_code)
+    else:
+        raise ValueError, "Value must be of type int or float."
+
+    return target

--- a/learn_kernels.cu
+++ b/learn_kernels.cu
@@ -8,3 +8,16 @@ __global__ void kMultiplyBySigmoidGrad(float* act, float* target, const unsigned
         target[i] = target[i] * act[i] * (1.0f - act[i]);
     }
 }
+
+
+__global__ void kCalculateL1Penalty(float* mat, float alpha, float* target, const unsigned int len) {
+    const unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    const unsigned int numThreads = blockDim.x * gridDim.x;
+    float s;
+    float d;
+    
+    for(unsigned int i = idx; i < len; i+= numThreads) {
+        s = mat[i] ? copysignf(1., mat[i]) : 0.0;
+        target[i] = alpha > fabsf(mat[i]) ? mat[i] : alpha*s;
+    }
+}

--- a/learn_kernels.cuh
+++ b/learn_kernels.cuh
@@ -8,5 +8,6 @@
 #define NUM_SPARSE_GRAD_THREADS_PER_BLOCK    512
 
 __global__ void kMultiplyBySigmoidGrad(float* act, float* target, const unsigned int len);
+__global__ void kCalculateL1Penalty(float* act, float p, float* target, const unsigned int len);
 
 #endif

--- a/test_learn.py
+++ b/test_learn.py
@@ -24,5 +24,22 @@ def test_mult_by_sigmoid_deriv():
 
     assert np.max(np.abs(c_acts - g_acts.asarray())) < 10**-2, "Error in cudamat.learn.mult_by_sigmoid_deriv exceeded threshold"
 
+def test_calculate_l1_penalty():
+    m = 256
+    n = 128
+    p = 1
+    c_data = np.array(np.random.randn(m, n)*2, dtype=np.float32, order='F')
+    c_results = np.array(np.random.rand(m, n), dtype=np.float32, order='F')
+
+    g_data = cm.CUDAMatrix(c_data)
+    g_results = cm.CUDAMatrix(c_results)
+
+    d = p * np.sign(c_data)
+    c_results = np.where(np.abs(d) > np.abs(c_data), c_data, d)
+    cl.calculate_l1_penalty(g_data, p, g_results)
+    
+    assert np.max(np.abs(c_results - g_results.asarray())) < 10**-2, "Error in cudamat.learn.calculate_l1_penalty exceeded threshold"
+
+
 if __name__ == '__main__':
     nose.run()


### PR DESCRIPTION
This function can be used to calculate the L1 penalty update when training a Neural Net. It's much faster than doing:

```
    l1_penalty = alpha * np.sign(w)
    dw += np.where(alpha > np.abs(w), X, l1_penalty)
```

Since it's very focused on machine-learning application my guess was that this goes into learn.py instead of cudamat.py.

(I'm not too happy about the functionname BTW, let me know if you have a better name)
