### PR TITLE
Make test_* scripts run directly

### DIFF
--- a/test_cudamat.py
+++ b/test_cudamat.py
@@ -1167,4 +1167,4 @@ def test_where():
 
 
 if __name__ == '__main__':
-    nose.run()
+    nose.runmodule()

--- a/test_learn.py
+++ b/test_learn.py
@@ -25,4 +25,4 @@ def test_mult_by_sigmoid_deriv():
     assert np.max(np.abs(c_acts - g_acts.asarray())) < 10**-2, "Error in cudamat.learn.mult_by_sigmoid_deriv exceeded threshold"
 
 if __name__ == '__main__':
-    nose.run()
+    nose.runmodule()


### PR DESCRIPTION
Test scripts ran correctly when called using the `nosetests` script of nose, but when run directly with python, no tests were executed. Fixes #27.
