### PR TITLE
Install instructions: run test and benchmark from different directory

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -45,8 +45,9 @@ Testing
 To test your setup, run the included unit tests and optionally the benchmark:
 
 ```bash
+cd test  # so it doesn't try importing cudamat from the source directory
 # Run tests
 nosetests
 # Run benchmark
-python examples/bench_cudamat.py
+python ../examples/bench_cudamat.py
 ```


### PR DESCRIPTION
This updates the installation instructions to run `nosetests` and the benchmark script from within the `test` subdirectory, so Python will import cudamat from its installed location and not from the source directory (i.e., the `cudamat` subdirectory). Closes #51.