### PR TITLE
Issue #67: Python 3 support in init_random

### DIFF
--- a/cudamat/cudamat.cu
+++ b/cudamat/cudamat.cu
@@ -1,4 +1,6 @@
 #include <stdio.h>
+#include <errno.h>
+#include <string.h>
 #include <stdlib.h>
 #include <cublas.h>
 #include "cudamat_kernels.cuh"
@@ -26,6 +28,10 @@ EXPORT const char* get_last_cuda_error() {
     cudaError_t err = cudaGetLastError();
 
     return cudaGetErrorString( err);
+}
+
+EXPORT const char* get_last_clib_error() {
+    return strerror(errno);
 }
 
 EXPORT int cublas_init() {
@@ -60,11 +66,13 @@ EXPORT int init_random(rnd_struct* rnd_state, int seed, char* cudamatpath) {
 
     pFile = fopen (cudamatpath,"r");
     if (pFile == NULL) {
-        return -10;
+        return ERROR_FILE_OPEN;
     }
 
     for (int i = 0; i < NUM_RND_STREAMS; i++) {
-        fscanf (pFile, "%u", &host_mults[i]);
+        if (fscanf (pFile, "%u", &host_mults[i]) != 1) {
+            return ERROR_FILE_SCAN;
+        }
     }
     fclose (pFile);
 

--- a/cudamat/cudamat.cu
+++ b/cudamat/cudamat.cu
@@ -59,6 +59,9 @@ EXPORT int init_random(rnd_struct* rnd_state, int seed, char* cudamatpath) {
     FILE * pFile;
 
     pFile = fopen (cudamatpath,"r");
+    if (pFile == NULL) {
+        return -10;
+    }
 
     for (int i = 0; i < NUM_RND_STREAMS; i++) {
         fscanf (pFile, "%u", &host_mults[i]);

--- a/cudamat/cudamat.cuh
+++ b/cudamat/cudamat.cuh
@@ -15,6 +15,8 @@
 #define ERROR_TRANSPOSEDNESS -7
 #define ERROR_NOT_ON_DEVICE -8
 #define ERROR_UNSUPPORTED -9
+#define ERROR_FILE_OPEN -10
+#define ERROR_FILE_SCAN -11
 
 struct cudamat {
     float* data_host;

--- a/cudamat/cudamat.py
+++ b/cudamat/cudamat.py
@@ -143,6 +143,10 @@ def generate_exception(err_code):
         return CUDAMatException("Matrix is not in device memory.")
     elif err_code == -9:
         return CUDAMatException("Operation not supported.")
+    elif err_code == -10:
+        return CUDAMatException("Internal error.")
+    else:
+        return CUDAMatException("")
 
 
 class cudamat(ct.Structure):

--- a/cudamat/cudamat.py
+++ b/cudamat/cudamat.py
@@ -2,6 +2,7 @@ import os
 import platform
 import warnings
 import sysconfig
+import sys
 
 import ctypes as ct
 import numpy as np
@@ -238,6 +239,9 @@ class CUDAMatrix(object):
 
         cudamat_path = os.path.join(os.path.abspath(os.path.dirname(__file__)),
                                     'rnd_multipliers_32bit.txt')
+
+        if sys.version_info >= (3,):
+            cudamat_path = cudamat_path.encode(sys.getfilesystemencoding())
 
         err_code = _cudamat.init_random(CUDAMatrix.rnd_state_p,
                                         ct.c_int(seed),


### PR DESCRIPTION
Unfortunately, in 0141b1e I use a magic number as error code, but this is apparently how `cudamat` uses error codes. Closes #67.