### PR TITLE
Making get_last_cuda_error() Python3-compliant

### DIFF
--- a/cudamat/cudamat.py
+++ b/cudamat/cudamat.py
@@ -117,7 +117,11 @@ class CUDAMatException(Exception):
 
 
 def get_last_cuda_error():
-    return str(_cudamat.get_last_cuda_error())
+    errmsg = _cudamat.get_last_cuda_error()
+    if sys.version_info >= (3,):
+        return bytes(errmsg).decode()
+    else:
+        return str(errmsg)
 
 
 def get_last_clib_error():


### PR DESCRIPTION
As far I can see, this is the last bit of troubling unicode-related code for Python 3. The fix converts a byte-wide char string from the C library to a proper Unicode string, just like `get_last_clib_error()` does. `ctypes` desn't do it automatically.