### PR TITLE
Improve performance of dot() and sum()

### DIFF
--- a/cudamat/cudamat.cu
+++ b/cudamat/cudamat.cu
@@ -1228,11 +1228,20 @@ EXPORT int dot(cudamat* mat1, cudamat* mat2, cudamat* target, float beta, float 
         k = get_leading_dimension(mat2),
         n = get_nonleading_dimension(mat2);
 
-    cublasSgemm(get_transpose_char(mat1), get_transpose_char(mat2), 
-                m, n, k,
-                alpha, mat1->data_device, mat1->size[0],
-                mat2->data_device, mat2->size[0],
-                beta, target->data_device, target->size[0]);
+    // gemv if second matrix is a vector, gemm otherwise
+    if ((mat2->size[0] == 1) || (mat2->size[1] == 1)) {
+        cublasSgemv(get_transpose_char(mat1), mat1->size[0], mat1->size[1],
+                    alpha, mat1->data_device, mat1->size[0],
+                    mat2->data_device, 1,
+                    beta, target->data_device, 1);
+    }
+    else {
+        cublasSgemm(get_transpose_char(mat1), get_transpose_char(mat2),
+                    m, n, k,
+                    alpha, mat1->data_device, mat1->size[0],
+                    mat2->data_device, mat2->size[0],
+                    beta, target->data_device, target->size[0]);
+    }
 
     if (check_cublas_error())
         return CUBLAS_ERROR;

--- a/cudamat/cudamat.cu
+++ b/cudamat/cudamat.cu
@@ -1228,13 +1228,21 @@ EXPORT int dot(cudamat* mat1, cudamat* mat2, cudamat* target, float beta, float 
         k = get_leading_dimension(mat2),
         n = get_nonleading_dimension(mat2);
 
-    // gemv if second matrix is a vector, gemm otherwise
-    if ((mat2->size[0] == 1) || (mat2->size[1] == 1)) {
+    // gemv if second matrix is a (column) vector
+    if (n == 1) {
         cublasSgemv(get_transpose_char(mat1), mat1->size[0], mat1->size[1],
                     alpha, mat1->data_device, mat1->size[0],
                     mat2->data_device, 1,
                     beta, target->data_device, 1);
     }
+    // gemv if first matrix is a (row) vector
+    else if (m == 1) {
+        cublasSgemv(mat2->is_trans ? 'n' : 't', mat2->size[0], mat2->size[1],
+                    alpha, mat2->data_device, mat2->size[0],
+                    mat1->data_device, 1,
+                    beta, target->data_device, 1);
+    }
+    // gemm otherwise
     else {
         cublasSgemm(get_transpose_char(mat1), get_transpose_char(mat2),
                     m, n, k,

--- a/cudamat/cudamat.py
+++ b/cudamat/cudamat.py
@@ -1559,8 +1559,7 @@ def cublas_init(max_ones=(1024*256)):
     err = _cudamat.cublas_init()
     if err:
         raise CUDAMatException('error initializing CUBLAS: (err=%u)' % err)
-    CUDAMatrix.ones = CUDAMatrix(np.ones((max_ones, 1), dtype=np.float32,
-                                         order='F'))
+    CUDAMatrix.ones = empty((max_ones, 1)).assign(1.0)
 
 init = cublas_init
 

--- a/test/test_cudamat.py
+++ b/test/test_cudamat.py
@@ -1047,6 +1047,14 @@ def test_dot_vect():
     C = cm.dot(A.T, B.slice(0, m))
     assert np.max(np.abs(c - C.asarray())) < 10**-2, "Error in CUDAMatrix.dot exceeded threshold"
 
+    c = np.dot(b.T, a.T)
+    C = cm.dot(B.T, A.T)
+    assert np.max(np.abs(c - C.asarray())) < 10**-2, "Error in CUDAMatrix.dot exceeded threshold"
+
+    c = np.dot(b[:m].T, a)
+    C = cm.dot(B.slice(0, m).reshape((1, m)), A)
+    assert np.max(np.abs(c - C.asarray())) < 10**-2, "Error in CUDAMatrix.dot exceeded threshold"
+
 def test_add_dot():
     m = 128
     k = 256

--- a/test/test_cudamat.py
+++ b/test/test_cudamat.py
@@ -1030,6 +1030,23 @@ def test_dot_trans():
 
     assert np.max(np.abs(c - m3.numpy_array)) < 10**-2, "Error in CUDAMatrix.dot exceeded threshold"
 
+def test_dot_vect():
+    m = 128
+    k = 256
+    n = 1
+    a = np.array(np.random.randn(m, k)*10, dtype=np.float32, order='F')
+    b = np.array(np.random.randn(k, n)*10, dtype=np.float32, order='F')
+    A = cm.CUDAMatrix(a)
+    B = cm.CUDAMatrix(b)
+
+    c = np.dot(a, b)
+    C = cm.dot(A, B)
+    assert np.max(np.abs(c - C.asarray())) < 10**-2, "Error in CUDAMatrix.dot exceeded threshold"
+
+    c = np.dot(a.T, b[:m])
+    C = cm.dot(A.T, B.slice(0, m))
+    assert np.max(np.abs(c - C.asarray())) < 10**-2, "Error in CUDAMatrix.dot exceeded threshold"
+
 def test_add_dot():
     m = 128
     k = 256


### PR DESCRIPTION
This PR changes the dot product implementation to use gemv instead of gemm if either of the two matrix arguments is a vector. This speeds up sum() as well, which internally computes a dot product against a vector of ones.

Before:
```
In [1]: import cudamat as cmt
In [2]: cmt.init()
In [3]: X = cmt.CUDAMatrix(np.random.randn(1000, 2000))
In [4]: d = cmt.empty((1, 2000))
In [5]: %timeit X.sum(axis=0, target=d)
1000 loops, best of 3: 1.29 ms per loop
```

After:
```
1000 loops, best of 3: 446 µs per loop
```

Closes #74.