### PR TITLE
Simplify setup.py with custom compiler class

### DIFF
--- a/cudamat/cudamat.py
+++ b/cudamat/cudamat.py
@@ -8,13 +8,9 @@ import ctypes as ct
 import numpy as np
 
 def load_library(basename):
-    if platform.system() == 'Windows':
-       ext = '.dll'
-    else:
-       ext = sysconfig.get_config_var('SO')
     return ct.cdll.LoadLibrary(os.path.join(
         os.path.dirname(__file__) or os.path.curdir,
-        basename + ext))
+        basename + sysconfig.get_config_var('SO')))
 
 _cudamat = load_library('libcudamat')
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 import os
 # on Windows, we need the original PATH without Anaconda's compiler in it:
-PATH = os.environ.get('PATH')
+PATH = os.environ.get('PATH', '')
 from distutils.spawn import find_executable
 from setuptools import setup, find_packages, Extension
 import distutils.ccompiler

--- a/setup.py
+++ b/setup.py
@@ -3,111 +3,91 @@
 import os
 # on Windows, we need the original PATH without Anaconda's compiler in it:
 PATH = os.environ.get('PATH')
-from distutils.spawn import spawn, find_executable
+from distutils.spawn import find_executable
 from setuptools import setup, find_packages, Extension
-from setuptools.command.build_ext import build_ext
+import distutils.ccompiler
 import sys
+import sysconfig
 
-# CUDA specific config
-# nvcc is assumed to be in user's PATH
-nvcc_compile_args = ['-O3', '--ptxas-options=-v', '--compiler-options=-fPIC']
-nvcc_compile_args = os.environ.get('NVCCFLAGS', '').split() + nvcc_compile_args
+
+# First, we define two extensions, with some custom compilation flags:
+
+nvcc_flags = os.environ.get('NVCCFLAGS', '').split()
+
+if os.name == 'nt' and not '--compiler-bindir' in ''.join(nvcc_flags):
+    dirname = os.path.dirname(find_executable("cl.exe", PATH) or '')
+    if dirname:
+        nvcc_flags.extend(['--compiler-bindir', dirname])
+    else:
+        import warnings
+        warnings.warn("MSVC (cl.exe) not found on PATH. Compilation may "
+                      "fail. Either set PATH to include the path to MSVC, "
+                      "or set NVCCFLAGS=--compiler-bindir=... to define "
+                      "it. Possibly also set NVCCFLAGS=--cl-version=2010 "
+                      "to override nvcc's MSVC version detection.")
+
 cuda_libs = ['cublas']
-
 cudamat_ext = Extension('cudamat.libcudamat',
                         sources=['cudamat/cudamat.cu',
                                  'cudamat/cudamat_kernels.cu'],
                         libraries=cuda_libs,
-                        extra_compile_args=nvcc_compile_args)
+                        extra_compile_args=nvcc_flags,
+                        extra_link_args=nvcc_flags)
 cudalearn_ext = Extension('cudamat.libcudalearn',
                           sources=['cudamat/learn.cu',
                                    'cudamat/learn_kernels.cu'],
                           libraries=cuda_libs,
-                          extra_compile_args=nvcc_compile_args)
+                          extra_compile_args=nvcc_flags,
+                          extra_link_args=nvcc_flags)
 
 
-class CUDA_build_ext(build_ext):
+# Then we define a compiler for the extensions defined above:
+
+class NVCCCompiler(distutils.ccompiler.CCompiler):
     """
-    Custom build_ext command that compiles CUDA files.
-    Note that all extension source files will be processed with this compiler.
+    Custom CCompiler class that invokes nvcc no matter what.
     """
-    def build_extensions(self):
-        self.compiler.src_extensions.append('.cu')
-        self.compiler.set_executable('compiler_so', 'nvcc')
-        self.compiler.set_executable('linker_so', 'nvcc --shared')
-        if hasattr(self.compiler, '_c_extensions'):
-            self.compiler._c_extensions.append('.cu')  # needed for Windows
-        self.compiler.spawn = self.spawn
-        build_ext.build_extensions(self)
+    compiler_type = 'nvcc'
+    executables = {}
+    src_extensions = ('.cu',)
+    obj_extension = '.o' if os.name != 'nt' else '.obj'
+    shared_lib_extension = sysconfig.get_config_var('SO')
 
-    def spawn(self, cmd, search_path=1, verbose=0, dry_run=0):
-        """
-        Perform any CUDA specific customizations before actually launching
-        compile/link etc. commands.
-        """
-        if (sys.platform == 'darwin' and len(cmd) >= 2 and cmd[0] == 'nvcc' and
-                cmd[1] == '--shared' and cmd.count('-arch') > 0):
-            # Versions of distutils on OSX earlier than 2.7.9 inject
-            # '-arch x86_64' which we need to strip while using nvcc for
-            # linking
-            while True:
-                try:
-                    index = cmd.index('-arch')
-                    del cmd[index:index+2]
-                except ValueError:
-                    break
-        elif self.compiler.compiler_type == 'msvc':
-            # There are several things we need to do to change the commands
-            # issued by MSVCCompiler into one that works with nvcc. In the end,
-            # it might have been easier to write our own CCompiler class for
-            # nvcc, as we're only interested in creating a shared library to
-            # load with ctypes, not in creating an importable Python extension.
-            # - First, we replace the cl.exe or link.exe call with an nvcc
-            #   call. In case we're running Anaconda, we search cl.exe in the
-            #   original search path we captured further above -- Anaconda
-            #   inserts a MSVC version into PATH that is too old for nvcc.
-            cmd[:1] = ['nvcc', '--compiler-bindir',
-                       os.path.dirname(find_executable("cl.exe", PATH))
-                       or cmd[0]]
-            # - Secondly, we fix a bunch of command line arguments.
-            for idx, c in enumerate(cmd):
-                # create .dll instead of .pyd files
-                if '.pyd' in c: cmd[idx] = c = c.replace('.pyd', '.dll')
-                # replace /c by -c
-                if c == '/c': cmd[idx] = '-c'
-                # replace /DLL by --shared
-                elif c == '/DLL': cmd[idx] = '--shared'
-                # remove --compiler-options=-fPIC
-                elif '-fPIC' in c: del cmd[idx]
-                # replace /Tc... by ...
-                elif c.startswith('/Tc'): cmd[idx] = c[3:]
-                # replace /Fo... by -o ...
-                elif c.startswith('/Fo'): cmd[idx:idx+1] = ['-o', c[3:]]
-                # replace /LIBPATH:... by -L...
-                elif c.startswith('/LIBPATH:'): cmd[idx] = '-L' + c[9:]
-                # replace /OUT:... by -o ...
-                elif c.startswith('/OUT:'): cmd[idx:idx+1] = ['-o', c[5:]]
-                # remove /EXPORT:initlibcudamat or /EXPORT:initlibcudalearn
-                elif c.startswith('/EXPORT:'): del cmd[idx]
-                # replace cublas.lib by -lcublas
-                elif c == 'cublas.lib': cmd[idx] = '-lcublas'
-            # - Finally, we pass on all arguments starting with a '/' to the
-            #   compiler or linker, and have nvcc handle all other arguments
-            if '--shared' in cmd:
-                pass_on = '--linker-options='
-                # we only need MSVCRT for a .dll, remove CMT if it sneaks in:
-                cmd.append('/NODEFAULTLIB:libcmt.lib')
-            else:
-                pass_on = '--compiler-options='
-            cmd = ([c for c in cmd if c[0] != '/'] +
-                   [pass_on + ','.join(c for c in cmd if c[0] == '/')])
-            # For the future: Apart from the wrongly set PATH by Anaconda, it
-            # would suffice to run the following for compilation on Windows:
-            # nvcc -c -O -o <file>.obj <file>.cu
-            # And the following for linking:
-            # nvcc --shared -o <file>.dll <file1>.obj <file2>.obj -lcublas
-            # This could be done by a NVCCCompiler class for all platforms.
-        spawn(cmd, search_path, verbose, dry_run)
+    def _compile(self, obj, src, ext, cc_args, extra_postargs, pp_opts):
+        assert ext == '.cu'
+        self.spawn(['nvcc', '-O'] + cc_args + [src, '-o', obj] +
+                   (['--compiler-options=-fPIC']
+                    if os.name != 'nt' else []) +
+                   extra_postargs + pp_opts)
+
+    def link(self, target_desc, objects, output_filename, output_dir=None,
+             libraries=None, library_dirs=None, runtime_library_dirs=None,
+             export_symbols=None, debug=0, extra_preargs=None,
+             extra_postargs=None, build_temp=None, target_lang=None):
+        if output_dir is not None:
+            output_filename = os.path.join(output_dir, output_filename)
+        self.mkpath(os.path.dirname(output_filename))
+        self.spawn(['nvcc'] + (extra_preargs or []) +
+                   ['--shared', '-o', output_filename] + objects +
+                   list('-l%s' % lib for lib in libraries
+                        if not lib.startswith('python')) +
+                   list('-L%s' % libdir for libdir in library_dirs) +
+                   (extra_postargs or []) + (['-G'] if debug else []))
+
+
+# We want setuptools to use NVCCCompiler. The compiler is instantiated in
+# build_ext.run(), so we could write a custom build_ext command for this.
+# However, build_ext.run() does a lot of other stuff, so we would have to
+# copy the full method. To avoid this, we monkey-patch the function used
+# to instantiate the compiler at the beginning of build_ext.run():
+
+def new_compiler(plat=None, compiler=None, verbose=0, dry_run=0, force=0):
+    return NVCCCompiler(verbose, dry_run, force)
+
+distutils.ccompiler.new_compiler = new_compiler
+
+
+# Finally, we define our package:
 
 setup(name="cudamat",
       version="0.3",
@@ -118,4 +98,4 @@ setup(name="cudamat",
       package_data={'cudamat': ['rnd_multipliers_32bit.txt']},
       author="Volodymyr Mnih",
       url="https://github.com/cudamat/cudamat",
-      cmdclass={'build_ext': CUDA_build_ext})
+      )

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ class NVCCCompiler(distutils.ccompiler.CCompiler):
 
     def _compile(self, obj, src, ext, cc_args, extra_postargs, pp_opts):
         assert ext == '.cu'
-        self.spawn(['nvcc', '-O'] + cc_args + [src, '-o', obj] +
+        self.spawn(['nvcc', '-O3'] + cc_args + [src, '-o', obj] +
                    (['--compiler-options=-fPIC']
                     if os.name != 'nt' else []) +
                    extra_postargs + pp_opts)


### PR DESCRIPTION
This removes the `build_ext` hack overriding `compiler.spawn` to modify the compilation commands into proper `nvcc` calls depending on the platform (i.e., do nothing on Unix, but a lot on Windows). Instead, it defines a `NVCCCompiler` class that basically runs the same `nvcc` calls no matter whether on Linux, Mac or Windows. This makes `setup.py` less brittle, and should also resolve problems with wrong MSVC versions being used on Windows.

Tested on Ubuntu, and on Windows 7 with WinPython 3.4 and the Windows Platform SDK 7.1 (following [this guide](https://github.com/Lasagne/Lasagne/wiki/From-Zero-to-Lasagne-on-Windows-7-%2864-bit%29#c-compiler)).

If you're a Windows or Mac user, it would be nice if you could test this as well and report back. You can download the modified version at http://github.com/f0k/cudamat/archive/simplify-compile.zip and attempt to install it as in the [current installation guide](https://github.com/cudamat/cudamat/blob/6f4dbc773bfd0fa2b1d38939837b9019ac21d26e/INSTALL.md). A direct `pip install http://github.com/f0k/cudamat/archive/simplify-compile.zip` should also work. Set the `PATH` or `NVCCFLAGS` environment variables as needed. On Windows, especially pay attention to `--compiler-bindir` and `--cl-version` for the `NVCCFLAGS` if you run into trouble -- I'll extend the installation guide accordingly.

Closes #53.
